### PR TITLE
Função acender/apagar LED Verde GPIO11 pressionando "1"

### DIFF
--- a/src/lib/led.c
+++ b/src/lib/led.c
@@ -30,6 +30,18 @@ void blink_led(uint8_t LED, uint32_t ms, uint8_t cycles) {
 
 void led_action(char key) {
 
+    // Verificação se tecla digitada foi "1" acende LED
+    if (key =='1')
+    {
+        if(!gpio_get(LED_GREEN)) 
+        {
+            turn_led_on(LED_GREEN);
+        }
+        else
+        {
+            turn_led_off(LED_GREEN);
+        }
+    }
     if (key == '3'){
         if (gpio_get(LED_RED)){
             turn_led_off(LED_RED);


### PR DESCRIPTION
Implementada a função acender/apagar LED Verde GPIO11 quando pressionado a tecla 1. 